### PR TITLE
IdStore.getId() and make() methods support the non-migrated data as a fallback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>unique-id</artifactId>
-  <version>1.3-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
   <name>Unique ID Library Plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Unique+Id+Plugin</url>

--- a/src/main/java/org/jenkinsci/plugins/uniqueid/impl/LegacyIdStore.java
+++ b/src/main/java/org/jenkinsci/plugins/uniqueid/impl/LegacyIdStore.java
@@ -5,6 +5,9 @@ import hudson.ExtensionPoint;
 import jenkins.model.Jenkins;
 
 import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import javax.annotation.CheckForNull;
 
 import javax.annotation.Nullable;
 
@@ -22,7 +25,7 @@ import org.kohsuke.accmod.restrictions.NoExternalUse;
  * common for users top copy items either through the UI or manually and this will cause the
  * IDs to become non-unique.
  * 
- *
+ * 
  * @param <T>
  */
 @Restricted(NoExternalUse.class)
@@ -67,6 +70,23 @@ public abstract class LegacyIdStore<T> implements ExtensionPoint {
             }
         }
         return null;
+    }
+    
+    /**
+     * Retrieve all {@link LegacyIdStore}s for the given type.
+     * @param clazz Class
+     * @param <C> type of {@link LegacyIdStore}s
+     * @return A list of all matching {@link LegacyIdStore}s
+     */
+    @CheckForNull
+    public static <C> List<LegacyIdStore<C>> allForClass(Class<C> clazz) {
+        List<LegacyIdStore<C>> res = new LinkedList<LegacyIdStore<C>>();
+        for (LegacyIdStore store : Jenkins.getInstance().getExtensionList(LegacyIdStore.class)) {
+            if (store.supports(clazz)) {
+                res.add((LegacyIdStore<C>)store);
+            }
+        }
+        return res;
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/uniqueid/IdTest.java
+++ b/src/test/java/org/jenkinsci/plugins/uniqueid/IdTest.java
@@ -1,34 +1,93 @@
 package org.jenkinsci.plugins.uniqueid;
 
 import com.cloudbees.hudson.plugins.folder.Folder;
+import hudson.ExtensionList;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Job;
+import hudson.model.PersistenceRoot;
 import hudson.model.Project;
+import hudson.model.Run;
+import java.util.List;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.uniqueid.impl.JobIdStore;
+import org.jenkinsci.plugins.uniqueid.impl.LegacyIdStore;
+import org.jenkinsci.plugins.uniqueid.implv2.PersistenceRootIdStore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.junit.Assert.*;
+import org.junit.Before;
 
 public class IdTest {
 
     @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();
-
+    PersistenceRootIdStore newStore ;
+    JobIdStore oldStore;
+    
+    /**
+     * This implementation also checks the consistency of stores in the plugin
+     */
     @Test
-    public void project() throws Exception {
+    public void checkStoresUniqueStatus() {
+        // Retrieve the new store class
+        List<IdStore<PersistenceRoot>> extensions = IdStore.allForClass(PersistenceRoot.class);
+        assertEquals(1, extensions.size());
+        assertTrue(extensions.get(0) instanceof PersistenceRootIdStore);
+        newStore = (PersistenceRootIdStore) extensions.get(0);
+   
+        // Retrieve the old store class
+        List<LegacyIdStore<Job>> oldExtensions = LegacyIdStore.allForClass(Job.class);
+        assertEquals(1, oldExtensions.size());
+        assertTrue(oldExtensions.get(0) instanceof JobIdStore);
+        oldStore = (JobIdStore) oldExtensions.get(0);
+    }
+   
+    @Test
+    public void projectWithOldRunIdStore() throws Exception {
+        final Project p = jenkinsRule.createFreeStyleProject();
+        assertNull(IdStore.getId(p));
+     
+        // Emulate old project property injection
+        p.addProperty(new JobIdStore.JobIdProperty());
+        String projectId = IdStore.getId(p);
+        assertNotNull(LegacyIdStore.forClass(Project.class).get(p));
+        assertNull(IdStore.forClass(Project.class).get(p));
+        
+        // We're able to retrieve build Id based on the legacy Id instance
+        AbstractBuild build = jenkinsRule.buildAndAssertSuccess(p);
+        final String buildId = IdStore.getId(build);
+        assertNotNull(buildId);
+        assertNull(LegacyIdStore.forClass(Run.class).get(build));
+        assertNotNull(IdStore.forClass(Run.class).get(build));
+             
+        // Roundtrip, check the migration to the new IdStore completes correctly
+        IdStore.makeId(build);
+        jenkinsRule.jenkins.reload();
+        AbstractProject resurrectedProject = jenkinsRule.jenkins.getItemByFullName(p.getFullName(), AbstractProject.class);
+        assertEquals(projectId, IdStore.getId(resurrectedProject));
+        assertEquals(buildId, IdStore.forClass(Run.class).get(build));
+        
+        assertEquals(buildId, IdStore.getId(resurrectedProject.getBuild(build.getId())));
+    }
+    
+    @Test
+    public void projectWithNewRunIdStore() throws Exception {
         Project p = jenkinsRule.createFreeStyleProject();
         assertNull(IdStore.getId(p));
+        
         IdStore.makeId(p);
         String id = IdStore.getId(p);
         AbstractBuild build = jenkinsRule.buildAndAssertSuccess(p);
 
-        assertNull(IdStore.getId(build));
+        final String buildId = IdStore.getId(build);
+        assertNotNull(buildId); // Will be calculated from RPersistenceRootIdStore
         IdStore.makeId(build);
-        String buildId = IdStore.getId(build);
+        
+        // Roundtrip   
         jenkinsRule.jenkins.reload();
-
         AbstractProject resurrectedProject = jenkinsRule.jenkins.getItemByFullName(p.getFullName(), AbstractProject.class);
         assertEquals(id, IdStore.getId(resurrectedProject));
         assertEquals(buildId, IdStore.getId(resurrectedProject.getBuild(build.getId())));


### PR DESCRIPTION
This change allows to operate properly if the data has not been migrated correctly or has been loaded after the start (Job Config History, Manual copy, etc.). Also extends and fixes unit tests.

@reviewbybees
